### PR TITLE
Revert https://github.com/SciML/NeuralNetDiffEq.jl/commit/3babce713d7…

### DIFF
--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -52,7 +52,7 @@ function DiffEqBase.solve(
         if u0 isa Number
             phi = (t,θ) -> u0 + (t-tspan[1])*first(chain(adapt(typeof(θ),[t]),θ))
         else
-            phi = (t,θ) -> u0 .+ (t-tspan[1]) .* chain(adapt(typeof(θ),[t]),θ)
+            phi = (t,θ) -> u0 + (t-tspan[1]) * chain(adapt(typeof(θ),[t]),θ)
         end
     else
         _,re  = Flux.destructure(chain)

--- a/src/ode_solve.jl
+++ b/src/ode_solve.jl
@@ -60,7 +60,7 @@ function DiffEqBase.solve(
         if u0 isa Number
             phi = (t,θ) -> u0 + (t-tspan[1])*first(re(θ)(adapt(typeof(θ),[t])))
         else
-            phi = (t,θ) -> u0 .+ (t-tspan[1]) .* re(θ)(adapt(typeof(θ),[t]))
+            phi = (t,θ) -> u0 + (t-tspan[1]) * re(θ)(adapt(typeof(θ),[t]))
         end
     end
 


### PR DESCRIPTION
…166012889c8d98e280e084001d5c9

This is hiding issues with mis-shaped NN outputs.